### PR TITLE
Set the FS to allow root

### DIFF
--- a/pCloudCC/lib/pclsync/pfs.c
+++ b/pCloudCC/lib/pclsync/pfs.c
@@ -3420,6 +3420,7 @@ static int psync_fs_do_start(){
   if (!is_fuse3_installed_on_system()) {
     fuse_opt_add_arg(&args, "-ononempty");
   }
+  fuse_opt_add_arg(&args, "-oallow_root");
   fuse_opt_add_arg(&args, "-ohard_remove");
 //  fuse_opt_add_arg(&args, "-d");
 #endif


### PR DESCRIPTION
This should probably be a option, but I needed it for my set up so I set it as hard coded here. For this to work, the user needs to add or uncomment `user_allow_other` in `/etc/fuse.conf` 

The main reason I'm making this pull request is to allow others who have the same issue to have a solution. (You could checkout my branch and build it using the same instructions in the README)

This is primarily of use to allow Docker to access a mounted pCloud filesystem. Without this you get an error something like:
```
docker: Error response from daemon: error while creating mount source path '/mnt/xyz/container-dir': mkdir /mnt/xyz: file exists.
```

When trying to mount a folder within the pCloud FS as a docker volume